### PR TITLE
Add internet connectivity verification at script start

### DIFF
--- a/architect.sh
+++ b/architect.sh
@@ -38,6 +38,7 @@ source src/end.sh
 source src/de/detect.sh
 source src/software/flatpak.sh
 source src/software/install.sh
+source src/system/internet.sh
 source src/system/config/aur.sh
 source src/system/config/pacman.sh
 source src/system/drivers/devices.sh
@@ -77,6 +78,8 @@ function little_step() {
 }
 # ================================================================================================ #
 function main() {
+    check_internet || exit 1
+
     local -r start_time="$(date +%s)"
     # init
     print_center "Initialization" "${GREEN}"

--- a/src/cmd.sh
+++ b/src/cmd.sh
@@ -22,16 +22,8 @@ function exec() {
 }
 
 function exec_log() {
-    if [[ $# -ne 2 ]]; then
-        echo -e "${RED}Usage: exec_log <command> <message>${RESET}"
-        exit 1
-    fi
-
-    local -r command="$1"
-    local -r comment="$2"
-
-    log_msg "${comment}"
-    exec "${command}"
+    log_msg "$1"
+    exec "$2"
 }
 
 function install_one() {

--- a/src/system/internet.sh
+++ b/src/system/internet.sh
@@ -1,0 +1,13 @@
+source src/cmd.sh
+
+function check_internet() {
+    tool='curl'
+    tool_opts='-s --connect-timeout 8'
+
+    if ! $tool $tool_opts https://archlinux.org/ >/dev/null 2>&1; then
+        echo -e "${RED}Error: No Internet connection${RESET}"
+        return 1
+    fi
+
+    return 0
+}


### PR DESCRIPTION
Add internet connectivity verification at script start

## Overview
This update enhances the script's reliability and usability by adding an initial internet connectivity verification. It also includes a minor modification to the `exec_log()` function.

## Changes
- Introduced a new script, `src/internet.sh`, dedicated to checking internet connectivity.
- Implemented the `check_internet()` function within the script, which:
  - Exits the program with a status code of 1 if no internet connection is found, ensuring the script runs only under suitable network conditions.
  - Proceeds with normal script operations by returning a status code of 0 when an active internet connection is detected.
