### PR TITLE
fix: nvidia.sh syntax error

### DIFF
--- a/src/system/drivers/nvidia.sh
+++ b/src/system/drivers/nvidia.sh
@@ -1,7 +1,7 @@
 source src/cmd.sh
 
 function nvidia_config() {
-        exec_log "echo -e 'options nvidia-drm.modeset=1' | sudo tee -a /etc/modprobe.d/nvidia.conf" "Setting nvidia-drm.modeset=1 option"
+        exec_log "echo -e 'options nvidia-drm modeset=1' | sudo tee -a /etc/modprobe.d/nvidia.conf" "Setting nvidia-drm modeset=1 option"
 }
 
 function nvidia_drivers() {


### PR DESCRIPTION
change option nvidia-drm modeset=1

syntax error identified on discord while using modprobe i2c for openrgb.