### PR TITLE
Change target of sed command grub-btrfs.sh

### DIFF
--- a/src/system/grub-btrfs.sh
+++ b/src/system/grub-btrfs.sh
@@ -6,6 +6,6 @@ function grub-btrfs() {
         install_lst "timeshift grub-btrfs timeshift-autosnap"
         exec_log "sudo systemctl enable --now cronie.service" "Enable cronie"
         exec_log "sudo systemctl enable --now grub-btrfsd" "Enable grub-btrfsd"
-        exec_log "sudo sed -i 's|ExecStart=/usr/bin/grub-btrfsd --syslog /.snapshots|ExecStart=/usr/bin/grub-btrfsd --syslog --timeshift-auto|' /usr/lib/systemd/system/grub-btrfsd.service" "setup grub-btrfsd for timeshift"
+        exec_log "sudo sed -i 's|ExecStart=/usr/bin/grub-btrfsd --syslog /.snapshots|ExecStart=/usr/bin/grub-btrfsd --syslog --timeshift-auto|' /etc/systemd/system/multi-user.target.wants/grub-btrfsd.service" "setup grub-btrfsd for timeshift"
     fi
 }


### PR DESCRIPTION
Change target of sed command, from /usr/lib/systemd/system, which is a generated file, to /etc/systemd/system

More information here :
https://unix.stackexchange.com/questions/206315/whats-the-difference-between-usr-lib-systemd-system-and-etc-systemd-system

"Modification made by system administrator go into /etc/systemd/system"