### PR TITLE
fix(typo): change `service`, which is incorrect, to `timer`

### DIFF
--- a/src/system/config/pacman.sh
+++ b/src/system/config/pacman.sh
@@ -7,7 +7,7 @@ function config_pacman() {
     exec_log "sudo sed -i '/^#\[multilib\]/,/^#Include = \/etc\/pacman.d\/mirrorlist/ s/^#//' '/etc/pacman.conf'" "Enabling multilib repository"
     exec_log "sudo sed -i 's/#MAKEFLAGS=\"-j2\"/MAKEFLAGS=\"-j\$(nproc)\"/' /etc/makepkg.conf" "Enabling multithread compilation"
     exec_log "sudo pacman -S pacman-contrib --noconfirm" "Installing pacman-contrib"
-    exec_log "sudo systemctl enable --now paccache.timer" "Enabling paccache service"
+    exec_log "sudo systemctl enable --now paccache.timer" "Enabling paccache timer"
 }
 
 function mirrorlist() {


### PR DESCRIPTION
Simply fixing a typo mistake in the `pacman.sh` file: we are enabling the paccache **timer**, not the **service** :smiley: 